### PR TITLE
Add note about primary domain delivery

### DIFF
--- a/source/howtos/multi-domain.rst
+++ b/source/howtos/multi-domain.rst
@@ -530,6 +530,14 @@ afterwords and reload postfix.
 
 Currently there's no automated process or ldap equivalent configuration for it.
 
+**Primary Domain Delivery**
+
+If your primary domain needs to accept mail, the original setup-kolab command used
+to create the initial setup will have created multiple aliases under the primary domain. 
+This will cause mail to no longer be deliverable to the primary domain. Depending on 
+your requirements you may need to remove them. Login to kola-webadmin and remove the 
+domains aliases with more than three components.
+
 Roundcube Changes
 =================
 


### PR DESCRIPTION
When converting a single domain to multi-domain setup the primary domain seems to not be able to accept mail anymore. The common problem is that the original setup-kolab command creates multiple aliases which for whatever reason cause the hosted_triplet/hosted_duplet files to not find the domain. This adds a paragraph description the potential need for this change.